### PR TITLE
fix: strip intermediate assistant messages between MCP tool calls from reply

### DIFF
--- a/src/TgLlmBot/Commands/ChatWithLlm/Services/DefaultLlmChatHandler.cs
+++ b/src/TgLlmBot/Commands/ChatWithLlm/Services/DefaultLlmChatHandler.cs
@@ -127,7 +127,24 @@ public partial class DefaultLlmChatHandler : ILlmChatHandler
                 RawRepresentationFactory = static _ => LlmRawRequestFactory.CreateChatCompletionOptions()
             };
             var llmResponse = await _chatClient.GetResponseAsync(request.Messages, chatOptions, cancellationToken);
-            var rawLLmResponse = llmResponse.Text.Trim();
+            // ChatResponse.Text склеивает текст всех сообщений ответа, а FunctionInvokingChatClient
+            // складывает туда и промежуточные реплики модели между вызовами MCP-инструментов.
+            // Наружу идёт только финальный ответ: всё, что модель написала после последнего
+            // вызова инструмента (финальный текст может занимать несколько сообщений подряд).
+            var lastToolCallIndex = -1;
+            for (var i = 0; i < llmResponse.Messages.Count; i++)
+            {
+                if (llmResponse.Messages[i].Contents.Any(static content => content is FunctionCallContent))
+                {
+                    lastToolCallIndex = i;
+                }
+            }
+
+            var rawLLmResponse = string.Concat(llmResponse.Messages
+                    .Skip(lastToolCallIndex + 1)
+                    .Where(static message => message.Role == ChatRole.Assistant)
+                    .Select(static message => message.Text))
+                .Trim();
             var llmResponseText = rawLLmResponse;
             if (string.IsNullOrWhiteSpace(rawLLmResponse))
             {

--- a/src/TgLlmBot/Commands/ChatWithLlm/Services/DefaultLlmChatHandler.cs
+++ b/src/TgLlmBot/Commands/ChatWithLlm/Services/DefaultLlmChatHandler.cs
@@ -131,14 +131,9 @@ public partial class DefaultLlmChatHandler : ILlmChatHandler
             // складывает туда и промежуточные реплики модели между вызовами MCP-инструментов.
             // Наружу идёт только финальный ответ: всё, что модель написала после последнего
             // вызова инструмента (финальный текст может занимать несколько сообщений подряд).
-            var lastToolCallIndex = -1;
-            for (var i = 0; i < llmResponse.Messages.Count; i++)
-            {
-                if (llmResponse.Messages[i].Contents.Any(static content => content is FunctionCallContent))
-                {
-                    lastToolCallIndex = i;
-                }
-            }
+            var lastToolCallIndex = llmResponse.Messages
+                .ToList()
+                .FindLastIndex(static message => message.Contents.Any(static content => content is FunctionCallContent));
 
             var rawLLmResponse = string.Concat(llmResponse.Messages
                     .Skip(lastToolCallIndex + 1)


### PR DESCRIPTION
ChatResponse.Text concatenates text from all response messages, and FunctionInvokingChatClient puts the whole tool-call loop into Messages, including the model's narration between tool calls. All of that was sent to the chat along with the final answer.

Now only the text written after the last tool call is sent.